### PR TITLE
Bug fix: Don't immediately debounce

### DIFF
--- a/src/app/containers/AppContainer.js
+++ b/src/app/containers/AppContainer.js
@@ -18,6 +18,8 @@ export default class AppContainer extends Component {
 
     this.handleButtonClick = this.handleButtonClick.bind(this);
 
+    this.setSearch = debounce(this.setSearch.bind(this), 200);
+
     this.state = {
       searchTerm: '',
       entities,
@@ -29,12 +31,14 @@ export default class AppContainer extends Component {
 
   handleInput(event) {
     const term = event.target.value;
-    debounce(searchTerm => {
-      this.setState({
-        searchTerm,
-        searchResults: this.getEntitiesForTerm(searchTerm),
-      });
-    }, 100)(term);
+    this.setSearch(term);
+  }
+
+  setSearch(searchTerm) {
+    this.setState({
+      searchTerm,
+      searchResults: this.getEntitiesForTerm(searchTerm),
+    });
   }
 
   getEntitiesForTerm(term) {

--- a/src/app/containers/AppContainer.js
+++ b/src/app/containers/AppContainer.js
@@ -14,7 +14,7 @@ export default class AppContainer extends Component {
   constructor(props) {
     super(props);
 
-    this.handleInput = debounce(this.handleInput.bind(this), 200, true);
+    this.handleInput = this.handleInput.bind(this);
 
     this.handleButtonClick = this.handleButtonClick.bind(this);
 
@@ -29,10 +29,12 @@ export default class AppContainer extends Component {
 
   handleInput(event) {
     const searchTerm = event.target.value;
-    this.setState({
-      searchTerm,
-      searchResults: this.getEntitiesForTerm(searchTerm),
-    });
+    debounce(term => {
+      this.setState({
+        searchTerm,
+        searchResults: this.getEntitiesForTerm(searchTerm),
+      });
+    }, 100)(searchTerm);
   }
 
   getEntitiesForTerm(term) {

--- a/src/app/containers/AppContainer.js
+++ b/src/app/containers/AppContainer.js
@@ -28,13 +28,13 @@ export default class AppContainer extends Component {
   }
 
   handleInput(event) {
-    const searchTerm = event.target.value;
-    debounce(term => {
+    const term = event.target.value;
+    debounce(searchTerm => {
       this.setState({
         searchTerm,
         searchResults: this.getEntitiesForTerm(searchTerm),
       });
-    }, 100)(searchTerm);
+    }, 100)(term);
   }
 
   getEntitiesForTerm(term) {


### PR DESCRIPTION
Steps to reproduce:
1. Type in "pare"
2. Press and hold backspace

You can observe the search box is empty, but the search results are still limited to a search subset. This happens because the `at_start` argument was passed to `just-debounce`, so it debounced on the first `change` event (pressing the backspace) but not for the following events (emptying the search box). The search results are then stuck at somewhere between "pare" and "".

If we delay the debounce to the end of the 200ms window, React gets angry because it doesn't like it when you use synthetic events at later times. We can store the `searchTerm` immediately in `handleInput` scope so that the synthetic event can be discarded and the debounce can use the variable that's in the parent scope rather than the event.

This makes search have a slight delay, so I reduced it to 100ms so the delay is less annoying. What do you think?